### PR TITLE
Tighten up JSON decoding and error handling.

### DIFF
--- a/src/Api/JsonClient.php
+++ b/src/Api/JsonClient.php
@@ -71,6 +71,30 @@ class JsonClient
     }
 
     /**
+     * Magic call for service method
+     *
+     * @param string $name
+     * @param array $params
+     * @return mixed
+     */
+    public function __call($name, array $params)
+    {
+        $data = array(
+            'method' => $name
+        );
+        foreach ($params as $i => $param) {
+            if (is_array($param)) {
+                $param = json_encode($param);
+            }
+            $data['arg' . $i] = $param;
+        }
+
+        $json = $this->postRequest($data);
+
+        return $this->decodeJson($json);
+    }
+
+    /**
      * Post request
      *
      * @param array $data
@@ -130,12 +154,13 @@ class JsonClient
 
         if ((int)$code != 200) {
             try {
-                $message = (array)$this->decodeJson($content);
-                if (array_key_exists('msg', $message)) {
-                    $content = $message['msg'];
+                $message = $this->decodeJson($content);
+                if ($message instanceof \stdClass && isset($message->msg)) {
+                    $content = $message->msg;
                 }
             } catch (\UnexpectedValueException $e) {
                 // Void
+                // Failed to decode, leave content as the raw response
             }
             throw new \RuntimeException($content, $code);
         }
@@ -167,23 +192,15 @@ class JsonClient
      * Decode JSON
      *
      * @param string $json
-     * @return \stdClass
+     * @return mixed
      * @throws \UnexpectedValueException
      */
     protected function decodeJson($json)
     {
         $result = json_decode($json, false);
 
-        // Error checking
-        $ver = version_compare(PHP_VERSION, '5.3');
-        if ($ver == '-1') {
-            // Less than php5.3
-            $error = '';
-            if ($result === null) {
-                $error = 'JSON was not able to be decoded';
-            }
-        } else {
-            // At least php5.3
+        if ($result === null) {
+            // Error checking
             switch (json_last_error()) {
                 case JSON_ERROR_DEPTH:
                     $error = 'Maximum stack depth exceeded';
@@ -196,41 +213,16 @@ class JsonClient
                     break;
                 case JSON_ERROR_NONE:
                 default:
+                    // Value is really null
                     $error = '';
                     break;
             }
-        }
 
-        if (!empty($error)) {
-            throw new \UnexpectedValueException("Problem decoding json ($json), {$error}");
+            if (!empty($error)) {
+                throw new \UnexpectedValueException("Problem decoding json ($json), {$error}");
+            }
         }
 
         return $result;
-    }
-
-    /**
-     * Magic call for service method
-     *
-     * @param string $name
-     * @param array $params
-     * @return \stdClass
-     */
-    public function __call($name, $params)
-    {
-        $data = array(
-            'method' => $name
-        );
-        foreach ($params as $i => $param) {
-            if (is_array($param)) {
-                $param = json_encode($param);
-            }
-            $data['arg' . $i] = $param;
-        }
-        $json = $this->postRequest($data);
-        if ($json == 'null') {
-            return null;
-        }
-
-        return $this->decodeJson($json);
     }
 }


### PR DESCRIPTION
PHP < 5.4 is not supported, remove error handling for earlier versions.
Move 'null' check into the decode method.
Change API exception handling to not cast to array.

@Pudge601 