### PR TITLE
Feature/upload helper

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,10 @@
         "psr/log" : "~1.0"
     },
 
+    "suggest": {
+        "ext-curl" : "cURL required to use the file upload helper"
+    },
+
     "autoload-dev": {
         "psr-4": {
             "Mxm\\": "tests/"

--- a/src/Api.php
+++ b/src/Api.php
@@ -55,6 +55,8 @@ use Mxm\Api\Helper;
  */
 class Api implements \Psr\Log\LoggerAwareInterface
 {
+    const VERSION = '2.0';
+
     /**
      * @var string
      */

--- a/src/Api/ConnectionTrait.php
+++ b/src/Api/ConnectionTrait.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Mxm\Api;
+
+use Mxm\Api;
+
+/**
+ * MXM JSON API Client
+ *
+ * @category   Mxm
+ * @package    Api
+ * @copyright  Copyright (c) 2007-2015 Emailcenter UK. (http://www.emailcenteruk.com)
+ * @license    Commercial
+ */
+trait ConnectionTrait
+{
+    /**
+     * @var string
+     */
+    protected $host;
+
+    /**
+     * @var string
+     */
+    protected $username;
+
+    /**
+     * @var string
+     */
+    protected $password;
+
+    /**
+     * @var bool
+     */
+    protected $useSsl;
+
+    /**
+     * Get connection socket
+     *
+     * @return resource
+     */
+    protected function getConnection()
+    {
+        $port = $this->useSsl ? 443 : 80;
+        $host = ($this->useSsl ? 'ssl://' : '') . $this->host;
+
+        $socket = @fsockopen($host, $port);
+        if ($socket === false) {
+            $error = error_get_last();
+            throw new \RuntimeException("Failed to connect to {$this->host} on port $port, {$error['message']}");
+        }
+
+        return $socket;
+    }
+
+    /**
+     * Get request headers
+     *
+     * @param int|null $contentLength bytes, null if unknown
+     * @return array
+     */
+    protected function getHeaders($contentLength)
+    {
+        $headers = array(
+            'Host'           => $this->host,
+            'Connection'     => 'close',
+            'Content-type'   => 'application/x-www-form-urlencoded',
+            'User-Agent'     => 'MxmJsonClient/' . Api::VERSION . ' PHP/' . phpversion()
+        );
+
+        if ($contentLength > 0) {
+            $headers['Content-length'] = (int)$contentLength;
+        }
+
+        if (!is_null($this->username) && !is_null($this->password)) {
+            $basicAuth                = base64_encode($this->username . ':' . $this->password);
+            $headers['Authorization'] = "Basic $basicAuth";
+        }
+
+        return $headers;
+    }
+
+    /**
+     * Build request string
+     * Body is optional, headers will not be terminated if body not provided
+     *
+     * @param string $uri
+     * @param array $headers
+     * @param string $body
+     * @return string
+     */
+    protected function buildPostRequest($uri, array $headers = [], $body = '')
+    {
+        $request = "POST {$uri} HTTP/1.0\r\n";
+
+        foreach ($headers as $key => $value) {
+            $request .= "$key: $value\r\n";
+        }
+
+        if (!empty($body)) {
+            $request .= "\r\n$body";
+        }
+
+        return $request;
+    }
+}

--- a/src/Api/ConnectionTrait.php
+++ b/src/Api/ConnectionTrait.php
@@ -72,10 +72,9 @@ trait ConnectionTrait
     /**
      * Get request headers
      *
-     * @param int|null $contentLength bytes, null if unknown
      * @return array
      */
-    protected function getHeaders($contentLength)
+    protected function getHeaders()
     {
         $headers = array(
             'Host'           => $this->host,
@@ -83,10 +82,6 @@ trait ConnectionTrait
             'Content-type'   => 'application/x-www-form-urlencoded',
             'User-Agent'     => 'MxmJsonClient/' . Api::VERSION . ' PHP/' . phpversion()
         );
-
-        if ($contentLength > 0) {
-            $headers['Content-length'] = (int)$contentLength;
-        }
 
         if (!is_null($this->username) && !is_null($this->password)) {
             $basicAuth                = base64_encode($this->username . ':' . $this->password);

--- a/src/Api/ConnectionTrait.php
+++ b/src/Api/ConnectionTrait.php
@@ -35,6 +35,22 @@ trait ConnectionTrait
     protected $useSsl;
 
     /**
+     * @param array $config {
+     *     @var string $host
+     *     @var string $user
+     *     @var string $pass
+     *     @var bool   $useSsl
+     * }
+     */
+    protected function setConnectionConfig($config)
+    {
+        $this->host     = $config['host'];
+        $this->username = $config['user'];
+        $this->password = $config['pass'];
+        $this->useSsl   = (bool)$config['useSsl'];
+    }
+
+    /**
      * Get connection socket
      *
      * @return resource

--- a/src/Api/Helper.php
+++ b/src/Api/Helper.php
@@ -68,7 +68,7 @@ class Helper
             "{$typePrimary[$type]}/{$primaryId}";
 
         // Set up stream
-        $headers = $this->getHeaders('');
+        $headers = $this->getHeaders();
         $opts = array(
             'http' => array(
                 'header' => "Authorization: {$headers['Authorization']}"

--- a/src/Api/Helper.php
+++ b/src/Api/Helper.php
@@ -14,6 +14,8 @@ use Mxm\Api;
  */
 class Helper
 {
+    use ConnectionTrait;
+
     /**
      * @var Api
      */
@@ -59,16 +61,17 @@ class Helper
         );
 
         // Build URL
-        $config = $this->api->getConfig();
-        $url = ($config['useSsl'] ? 'https' : 'http') .
-            "://{$config['host']}" .
+        $this->setConnectionConfig($this->api->getConfig());
+        $url = ($this->useSsl ? 'https' : 'http') .
+            "://{$this->host}" .
             "/download/{$type}/" .
             "{$typePrimary[$type]}/{$primaryId}";
 
         // Set up stream
+        $headers = $this->getHeaders('');
         $opts = array(
             'http' => array(
-                'header' => sprintf("Authorization: Basic %s\r\n", base64_encode($config['user'] . ':' . $config['pass']))
+                'header' => "Authorization: {$headers['Authorization']}"
             )
         );
         $context = stream_context_create($opts);
@@ -76,7 +79,7 @@ class Helper
         // Get file
         $this->api->getLogger()->debug("Download file {$type} {$primaryId}", [
             'url'  => $url,
-            'user' => $config['user']
+            'user' => $this->username
         ]);
         $local = @fopen($filename, 'w');
         if ($local === false) {
@@ -96,7 +99,7 @@ class Helper
         fclose($remote);
         $this->api->getLogger()->debug("Download complete {$type} {$primaryId}", [
             'url'  => $url,
-            'user' => $config['user']
+            'user' => $this->username
         ]);
 
         // Get MIME

--- a/src/Api/JsonClient.php
+++ b/src/Api/JsonClient.php
@@ -88,7 +88,8 @@ class JsonClient implements \Psr\Log\LoggerAwareInterface
         $socket = $this->getConnection();
 
         $body = http_build_query($data);
-        $headers = $this->getHeaders(strlen($body));
+        $headers = $this->getHeaders();
+        $headers['Content-length'] = strlen($body);
 
         $request = $this->buildPostRequest("/api/json/{$this->service}", $headers, $body);
 

--- a/src/Api/JsonClient.php
+++ b/src/Api/JsonClient.php
@@ -49,10 +49,7 @@ class JsonClient implements \Psr\Log\LoggerAwareInterface
     {
         $this->service = $service;
 
-        $this->host     = $config['host'];
-        $this->username = $config['user'];
-        $this->password = $config['pass'];
-        $this->useSsl   = (bool)$config['useSsl'];
+        $this->setConnectionConfig($config);
     }
 
     /**

--- a/src/Api/JsonTrait.php
+++ b/src/Api/JsonTrait.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Mxm\Api;
+
+use Mxm\Api;
+
+/**
+ * MXM JSON API Client
+ *
+ * @category   Mxm
+ * @package    Api
+ * @copyright  Copyright (c) 2007-2015 Emailcenter UK. (http://www.emailcenteruk.com)
+ * @license    Commercial
+ */
+trait JsonTrait
+{
+    /**
+     * Process JSON API response
+     *
+     * @param string $body
+     * @param int $httpCode
+     * @return string
+     * @throws \RuntimeException
+     */
+    protected function processJsonResponse($body, $httpCode)
+    {
+        if ((int)$httpCode != 200) {
+            try {
+                $message = $this->decodeJson($body);
+                if ($message instanceof \stdClass && isset($message->msg)) {
+                    $body = $message->msg;
+                }
+            } catch (\UnexpectedValueException $e) {
+                // Void
+                // Failed to decode, leave content as the raw response
+            }
+            throw new \RuntimeException($body, $httpCode);
+        }
+
+        return $body;
+    }
+
+    /**
+     * Decode JSON
+     *
+     * @param string $json
+     * @return mixed
+     * @throws \UnexpectedValueException
+     */
+    protected function decodeJson($json)
+    {
+        $result = json_decode($json, false);
+
+        if ($result === null) {
+            // Error checking
+            switch (json_last_error()) {
+                case JSON_ERROR_DEPTH:
+                    $error = 'Maximum stack depth exceeded';
+                    break;
+                case JSON_ERROR_CTRL_CHAR:
+                    $error = 'Unexpected control character found';
+                    break;
+                case JSON_ERROR_SYNTAX:
+                    $error = 'Syntax error, malformed JSON';
+                    break;
+                case JSON_ERROR_NONE:
+                default:
+                    // Value is really null
+                    $error = '';
+                    break;
+            }
+
+            if (!empty($error)) {
+                throw new \UnexpectedValueException("Problem decoding json ($json), {$error}");
+            }
+        }
+
+        return $result;
+    }
+}


### PR DESCRIPTION
@Pudge601 

Add upload helper. Used cURL in the end as getting it to work in native PHP became far too wacky!

Relies on traits to re-use connection and JSON methods, cementing the PHP 5.4 requirement which is already in master. For anyone requiring PHP 5.3, we can manually provide them an older `1.x` version.

Once in master, I'll update the README and tag a new `2.1` version (new features, but no BC breaks)