### PR TITLE
Curlfile

### DIFF
--- a/src/Api/Helper.php
+++ b/src/Api/Helper.php
@@ -63,14 +63,14 @@ class Helper
             '/api/json/file_upload';
 
 
-
-        //PHP 5.5. or later only. http://php.net/manual/en/class.curlfile.php
-        $file = new \CURLFile($path,$mime,$basename);
+        $file = "@{$path};filename={$basename};type={$mime}";
+        if (class_exists('\CURLFile')) { //PHP 5.5. or later only. http://php.net/manual/en/class.curlfile.php
+            $file = new \CURLFile($path, $mime, $basename);
+        }
 
         $params = array(
             'method' => 'handle',
             'key'    => $fileKey,
-            //'file'   => "@{$path};filename={$basename};type={$mime}"
             'file' => $file,
         );
 

--- a/src/Api/Helper.php
+++ b/src/Api/Helper.php
@@ -62,10 +62,16 @@ class Helper
             $this->host .
             '/api/json/file_upload';
 
+
+
+        //PHP 5.5. or later only. http://php.net/manual/en/class.curlfile.php
+        $file = new \CURLFile($path,$mime,$basename);
+
         $params = array(
             'method' => 'handle',
             'key'    => $fileKey,
-            'file'   => "@{$path};filename={$basename};type={$mime}"
+            //'file'   => "@{$path};filename={$basename};type={$mime}"
+            'file' => $file,
         );
 
         // Write request


### PR DESCRIPTION
CURLOPT_SAFE_UPLOAD is defaulted to TRUE in PHP 5.6. This means that using the @ prefix for file uploads in CURLOPT_POSTFIELDS is no longer supported in a default installation of 5.6. (http://php.net/manual/en/function.curl-setopt.php). 

This PR modifies the file upload helper so that it uses the CURLFile class instead of @ prefix in the file upload. (http://php.net/manual/en/class.curlfile.php). 

For versions of PHP where the CURLFile class is not available the old method is used. I have been unable to test this as I don't have an installation of PHP <=5.4!