### PR TITLE
Add logging and deprecation error for deprecated API methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ which extends the same `\RuntimeException` used previously.
 - `Helper::setLogLevel()` can be used to increase the log level from the default
 of *debug*. This might be useful if you want to see the file transfer logs at
 *info* and filter out the raw HTTP client logs at *debug*.
+- Deprecated API methods will be logged at *warning* level and trigger a PHP
+`E_USER_DEPRECATED` error.
 ### Changed
 - Namespaces have been changed from `Mxm\Api` to `Emailcenter\MaxemailApi`.
 - Deprecate API config keys for *user* and *pass*, replaced with *username* and

--- a/src/Client.php
+++ b/src/Client.php
@@ -165,6 +165,7 @@ class Client implements \Psr\Log\LoggerAwareInterface
         if ($this->httpClient === null) {
             $stack = HandlerStack::create();
             Middleware::addMaxemailErrorParser($stack);
+            Middleware::addWarningLogging($stack, $this->getLogger());
             Middleware::addLogging($stack, $this->getLogger());
             $this->httpClient = new GuzzleClient([
                 'base_uri' => $this->uri . 'api/json/',

--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -54,7 +54,7 @@ class Middleware
      */
     public static function addWarningLogging(HandlerStack $stack, LoggerInterface $logger)
     {
-        $middleware = GuzzleMiddleware::mapResponse(function (ResponseInterface $response) use ($stack, $logger) {
+        $middleware = GuzzleMiddleware::mapResponse(function (ResponseInterface $response) use ($logger) {
             if ($response->hasHeader('Warning')) {
                 foreach ($response->getHeader('Warning') as $message) {
                     // Code, agent, message, [date]
@@ -81,7 +81,7 @@ class Middleware
      */
     public static function addMaxemailErrorParser(HandlerStack $stack)
     {
-        $middleware = GuzzleMiddleware::mapResponse(function (ResponseInterface $response) use ($stack) {
+        $middleware = GuzzleMiddleware::mapResponse(function (ResponseInterface $response) {
             $code = $response->getStatusCode();
             if ($code < 400 || $code >= 500) {
                 // Allow success response to continue, and 500-level errors to be handled by Guzzle

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -59,6 +59,14 @@ class FunctionalTest extends TestCase
         $this->client->tree->fetchRoot('notATree', []);
     }
 
+    public function testDeprecatedMethod()
+    {
+        $this->expectException(\PHPUnit\Framework\Error\Deprecated::class);
+        $this->expectExceptionMessage('fetchRecentlyCompleted Deprecated');
+
+        $this->client->email_campaign->fetchRecentlyCompleted();
+    }
+
     /**
      * The file uploaded should be identical to the file then downloaded
      */


### PR DESCRIPTION
Check for the expected code and agent in any HTTP Warning headers, and then log the warning and trigger a deprecation error.

I'm less sure about the triggering of a PHP error, as that could be intrusive. However that's the driver for this change - to make sure that users are aware of their usage of deprecated methods.

---
Corresponds with the change in Maxemail to add the agent property to our existing Warnings.