### PR TITLE
Disable debug logging by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- HTTP Client debug logging is disabled by default to save resources if not
+needed. Enable by calling `enableDebugLogging()` before first call to an API
+service or helper.
 
 ## [4.0.0] - 2017-08-08
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Changed
 - HTTP Client debug logging is disabled by default to save resources if not
-needed. Enable by calling `enableDebugLogging()` before first call to an API
-service or helper.
+needed. Enable via the constructor's `debugLogging` option.
 
 ## [4.0.0] - 2017-08-08
 ### Added

--- a/src/Client.php
+++ b/src/Client.php
@@ -100,11 +100,12 @@ class Client implements \Psr\Log\LoggerAwareInterface
 
     /**
      * @param array $config {
-     *     @var string $username Required
-     *     @var string $password Required
-     *     @var string $uri      Optional. Default https://maxemail.emailcenteruk.com/
-     *     @var string $user     @deprecated See username
-     *     @var string $pass     @deprecated See password
+     *     @var string $username     Required
+     *     @var string $password     Required
+     *     @var string $uri          Optional. Default https://maxemail.emailcenteruk.com/
+     *     @var string $user         @deprecated See username
+     *     @var string $pass         @deprecated See password
+     *     @var bool   $debugLogging Optional. Enable logging of request/response. Default false
      * }
      */
     public function __construct(array $config)
@@ -133,6 +134,10 @@ class Client implements \Psr\Log\LoggerAwareInterface
                 throw new Exception\InvalidArgumentException('URI must contain protocol scheme and host');
             }
             $this->uri = "{$parsed['scheme']}://{$parsed['host']}/";
+        }
+
+        if (isset($config['debugLogging'])) {
+            $this->debugLoggingEnabled = (bool)$config['debugLogging'];
         }
     }
 
@@ -250,12 +255,5 @@ class Client implements \Psr\Log\LoggerAwareInterface
         }
 
         return $this->logger;
-    }
-
-    public function enableDebugLogging(bool $enable = true): Client
-    {
-        $this->debugLoggingEnabled = $enable;
-
-        return $this;
     }
 }

--- a/src/Client.php
+++ b/src/Client.php
@@ -94,6 +94,11 @@ class Client implements \Psr\Log\LoggerAwareInterface
     private $httpClient;
 
     /**
+     * @var bool
+     */
+    private $debugLoggingEnabled = false;
+
+    /**
      * @param array $config {
      *     @var string $username Required
      *     @var string $password Required
@@ -166,7 +171,9 @@ class Client implements \Psr\Log\LoggerAwareInterface
             $stack = HandlerStack::create();
             Middleware::addMaxemailErrorParser($stack);
             Middleware::addWarningLogging($stack, $this->getLogger());
-            Middleware::addLogging($stack, $this->getLogger());
+            if ($this->debugLoggingEnabled) {
+                Middleware::addLogging($stack, $this->getLogger());
+            }
             $this->httpClient = new GuzzleClient([
                 'base_uri' => $this->uri . 'api/json/',
                 'auth' => [
@@ -243,5 +250,12 @@ class Client implements \Psr\Log\LoggerAwareInterface
         }
 
         return $this->logger;
+    }
+
+    public function enableDebugLogging(bool $enable = true): Client
+    {
+        $this->debugLoggingEnabled = $enable;
+
+        return $this;
     }
 }


### PR DESCRIPTION
This causing issues for file uploads, as the whole file tries to be put into the log. Completely needless to have request/response logging for normal usage, so disable by default.

To be released as *4.0.1*